### PR TITLE
fix(groups): remove redirect causing infinite loop on group landing pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -561,11 +561,10 @@ add_filter( 'bp_groups_get_paged_groups_sql', 'hcommons_groups_sql_show_user_hid
 add_filter( 'bp_groups_get_total_groups_sql', 'hcommons_groups_sql_show_user_hidden' );
 
 /**
- * Save group admin settings for hidden nav tabs and landing page
+ * Save group admin settings for hidden nav tabs
  *
  * Hooks into the group settings save action to persist the admin's choices
- * for which navigation items to show/hide and which page to use as the
- * default landing page.
+ * for which navigation items to show or hide from regular members.
  *
  * @param int $group_id The ID of the group being edited.
  */
@@ -596,12 +595,6 @@ function hcommons_save_group_nav_settings( $group_id ) {
 
 	// Save hidden tabs to group meta
 	groups_update_groupmeta( $group_id, 'group_hidden_tabs', array_values( $hidden_tabs ) );
-
-	// Save landing page setting
-	if ( isset( $_POST['group-landing-page'] ) ) {
-		$landing_page = sanitize_text_field( $_POST['group-landing-page'] );
-		groups_update_groupmeta( $group_id, 'group_landing_page', $landing_page );
-	}
 }
 add_action( 'groups_group_settings_edited', 'hcommons_save_group_nav_settings' );
 
@@ -642,56 +635,6 @@ function hcommons_filter_group_nav_items() {
 	}
 }
 add_action( 'bp_actions', 'hcommons_filter_group_nav_items', 5 );
-
-/**
- * Redirect to group landing page when visiting group home
- *
- * When a group admin has set a custom landing page, redirect members
- * to that page instead of the default home/activity page.
- */
-function hcommons_group_landing_page_redirect() {
-	if ( ! bp_is_group() || ! bp_is_single_item() ) {
-		return;
-	}
-
-	$group_id = bp_get_current_group_id();
-	$landing_page = groups_get_groupmeta( $group_id, 'group_landing_page', true );
-
-	// Only redirect if a landing page is set and we're on the group home
-	if ( empty( $landing_page ) ) {
-		return;
-	}
-
-	// Get current action (the nav item slug we're viewing)
-	$current_action = bp_current_action();
-
-	// Only redirect from home/empty action to the landing page
-	// Don't redirect if we're already on another page or the landing page itself
-	if ( ! empty( $current_action ) && 'home' !== $current_action ) {
-		return;
-	}
-
-	// Don't redirect admins/mods if landing page is hidden
-	$hidden_tabs = groups_get_groupmeta( $group_id, 'group_hidden_tabs', true );
-	if ( ! bp_is_item_admin() && ! bp_is_item_mod() ) {
-		if ( is_array( $hidden_tabs ) && in_array( $landing_page, $hidden_tabs, true ) ) {
-			return; // Landing page is hidden from this user, don't redirect
-		}
-	}
-
-	// Build the redirect URL
-	$group_permalink = bp_get_group_url( groups_get_current_group() );
-	$redirect_url = trailingslashit( $group_permalink ) . $landing_page . '/';
-
-	// Prevent redirect loop
-	$current_url = bp_get_requested_url();
-	if ( trailingslashit( $current_url ) === trailingslashit( $redirect_url ) ) {
-		return;
-	}
-
-	bp_core_redirect( $redirect_url );
-}
-add_action( 'bp_actions', 'hcommons_group_landing_page_redirect', 1 );
 
 /**
  * Unslash xprofile field values before save to prevent wp_magic_quotes()


### PR DESCRIPTION
Fixes the theme side of MESH-Research/knowledge-commons-wordpress#78.

## Problem

Visiting a group root produced an infinite redirect loop for any group whose default landing page was set to **Activity**:

```
GET /groups/X/        → 302 → /groups/X/home/
GET /groups/X/home/   → 301 → /groups/X/
```

`hcommons_group_landing_page_redirect()` (hooked to `bp_actions`, priority 1) 302-redirected the group root to `/groups/X/{landing_page}/`. BuddyPress treats `/groups/X/home/` as non-canonical when the action equals the group default extension and 301-redirects back to the bare URL, so the two fought forever. The functions own loop guard only compared against its own redirect target, so it could not detect the two-hop loop.

hc-customs `bp_groups_default_extension` filter already renders the selected landing tab directly at the group root with no redirect, so the theme function was redundant in every non-looping case and harmful in the looping one — its only reachable behaviour was the bug.

## Changes

- Remove `hcommons_group_landing_page_redirect()` and its `add_action( 'bp_actions', 'hcommons_group_landing_page_redirect', 1 )` registration.
- Remove the dead `$_POST['group-landing-page']` branch in `hcommons_save_group_nav_settings()`. The settings form posts the field as `group-landing-page-select` (handled by hc-custom on `groups_settings_updated`), so the theme branch never executed. Docblock updated to match.

## Notes

- No behaviour is lost: landing-page selection continues to work through the existing hc-custom filter.
- `php -l` passes; no remaining references to the removed function or the `group_landing_page` handling exist in the theme.
- The production-data mitigation (clearing `group_landing_page = home` groupmeta on affected live groups) is tracked in the linked issue and is separate from this code change.