### PR TITLE
fix(buddypress): restore hover text contrast on creation buttons

### DIFF
--- a/assets/css/buddypress.css
+++ b/assets/css/buddypress.css
@@ -669,6 +669,13 @@
     background-color: #1b5e20;
     box-shadow: 0 4px 12px rgba(46, 125, 50, 0.4);
     transform: translateY(-1px);
+    /* Re-assert text colour and border on hover: bp-legacy's
+       equal-specificity hover rule sets color: #555 and
+       border: 1px solid #bbb, which otherwise survive this override and
+       leave near-invisible grey text on the dark green background
+       (group/site creation buttons, among others). */
+    color: white;
+    border: none;
 }
 
 /* Secondary/Outline Buttons */


### PR DESCRIPTION
## Problem

On the group-creation wizard and Create a Site form, button labels become nearly unreadable on hover (MESH-Research/hcommons-mpe-theme#20). BuddyPress legacy (`bp-legacy/css/buddypress.css`) styles `#buddypress` button hover with `background: #ededed; border: 1px solid #bbb; color: #555;`. This theme's hover rule in `assets/css/buddypress.css` overrides only the background (to dark green `#1b5e20`), box-shadow, and transform. Since the two rules have equal specificity and the theme sheet loads later, the theme's background wins but bp-legacy's undeclared-by-us `color: #555` and grey border survive — grey text on dark green at roughly 1.4:1 contrast.

## Fix

Add `color: white; border: none;` to the theme's existing generic button hover rule, so the hover state fully overrides bp-legacy rather than only partially. White on `#1b5e20` is 7.9:1, comfortably past WCAG AA. This covers every button using the shared pattern (Next Step / Back / Upload Image / Crop Image, site setup submit) without adding new selectors or touching shared plugins.

An earlier attempt (MESH-Research/knowledge-commons-wordpress#109) placed this override in the shared hc-styles plugin; that was withdrawn because hc-styles loads for all themes and would impose this theme's hover styling on themes that don't use it. The bug is in this theme's hover rule, so the fix now lives here.

Fixes MESH-Research/hcommons-mpe-theme#20