### PR TITLE
fix(bp-docs): restore page titles on docs directory and create screens

### DIFF
--- a/archive-bp_doc.php
+++ b/archive-bp_doc.php
@@ -25,6 +25,12 @@
 		<div id="buddypress">
 			<?php do_action( 'template_notices' ); ?>
 			<?php
+			// Show the directory title on the sitewide directories only;
+			// group docs lists render their own breadcrumb heading.
+			if ( ( function_exists( 'bp_docs_is_global_directory' ) && bp_docs_is_global_directory() )
+				|| ( function_exists( 'bp_docs_is_mygroups_directory' ) && bp_docs_is_mygroups_directory() ) ) {
+				hcommons_bp_docs_the_page_title();
+			}
 			// Try BP Docs specific content loading
 			if ( function_exists( 'bp_docs_locate_template' ) ) {
 				bp_docs_locate_template( 'docs-loop.php', true );

--- a/bp-docs-template.php
+++ b/bp-docs-template.php
@@ -28,6 +28,8 @@
 			if ( function_exists( 'bp_docs_locate_template' ) ) {
 				// Check for create/edit page
 				if ( function_exists( 'bp_docs_is_doc_create' ) && bp_docs_is_doc_create() ) {
+					// Show the "Create a Doc" page title
+					hcommons_bp_docs_the_page_title();
 					bp_docs_locate_template( 'single/edit.php', true );
 				} elseif ( function_exists( 'bp_docs_is_doc_edit' ) && bp_docs_is_doc_edit() ) {
 					// Show document title when editing
@@ -44,6 +46,12 @@
 					}
 					bp_docs_locate_template( 'single/index.php', true );
 				} else {
+					// Show the directory title on the sitewide directories only;
+					// group docs lists render their own breadcrumb heading.
+					if ( ( function_exists( 'bp_docs_is_global_directory' ) && bp_docs_is_global_directory() )
+						|| ( function_exists( 'bp_docs_is_mygroups_directory' ) && bp_docs_is_mygroups_directory() ) ) {
+						hcommons_bp_docs_the_page_title();
+					}
 					// Default to docs directory/list
 					bp_docs_locate_template( 'docs-loop.php', true );
 				}

--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Pure, WordPress-independent helpers.
 require_once __DIR__ . '/inc/works-url.php';
+require_once __DIR__ . '/inc/bp-docs-title.php';
 
 /**
  * Theme setup
@@ -179,6 +180,57 @@ function hcommons_bp_docs_template( $template ) {
 	return $template;
 }
 add_filter( 'template_include', 'hcommons_bp_docs_template', 99 );
+
+/**
+ * Get the page title for the current BuddyPress Docs screen.
+ *
+ * The theme bypasses BuddyPress theme compat for Docs pages (see
+ * hcommons_bp_docs_template()), so the dummy-post title BuddyPress Docs
+ * normally supplies is never rendered. This rebuilds that title from the
+ * plugin's own sources: "Create a Doc" on the creation screen, and the
+ * configured Docs directory title elsewhere.
+ *
+ * @return string The title for the current Docs screen.
+ */
+function hcommons_bp_docs_current_page_title() {
+	$view = ( function_exists( 'bp_docs_is_doc_create' ) && bp_docs_is_doc_create() ) ? 'create' : 'directory';
+
+	$directory_title = function_exists( 'bp_docs_get_docs_directory_title' )
+		? bp_docs_get_docs_directory_title()
+		: '';
+
+	return hcommons_bp_docs_page_title( $view, $directory_title );
+}
+
+/**
+ * Output the page heading for the current BuddyPress Docs screen.
+ *
+ * Uses the same h2.doc-title markup the Docs templates already use for
+ * single-doc views, so existing theme styles apply.
+ */
+function hcommons_bp_docs_the_page_title() {
+	echo '<h2 class="doc-title">' . esc_html( hcommons_bp_docs_current_page_title() ) . '</h2>';
+}
+
+/**
+ * Fix the document <title> on the Docs directory and create screens.
+ *
+ * Both screens run as the bp_doc post-type archive, so WordPress titles them
+ * all with the generic post type label ("Docs"). Use the real screen title
+ * instead. Single docs are is_singular queries and already get the doc's own
+ * title, so they are left alone.
+ *
+ * @param array $title The document title parts.
+ * @return array Filtered title parts.
+ */
+function hcommons_bp_docs_document_title_parts( $title ) {
+	if ( function_exists( 'bp_docs_is_doc_create' ) && is_post_type_archive( 'bp_doc' ) ) {
+		$title['title'] = hcommons_bp_docs_current_page_title();
+	}
+
+	return $title;
+}
+add_filter( 'document_title_parts', 'hcommons_bp_docs_document_title_parts' );
 
 /**
  * Get the blog ID for the "about" site based on environment

--- a/inc/bp-docs-title.php
+++ b/inc/bp-docs-title.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Pure helpers for resolving the page title on BuddyPress Docs screens.
+ *
+ * These functions are deliberately WordPress-independent so they can be
+ * exercised by the standalone tests in tests/test-bp-docs-title.php.
+ *
+ * @package HCommons
+ */
+
+if ( ! function_exists( 'hcommons_bp_docs_page_title' ) ) {
+	/**
+	 * Resolve the display title for a BuddyPress Docs page.
+	 *
+	 * @param string $view            The current Docs view: 'create' for the
+	 *                                doc-creation screen, anything else is
+	 *                                treated as a directory view.
+	 * @param string $directory_title The configured Docs directory title, if any.
+	 * @return string The title to display.
+	 */
+	function hcommons_bp_docs_page_title( $view, $directory_title = '' ) {
+		if ( 'create' === $view ) {
+			return function_exists( '__' ) ? __( 'Create a Doc', 'buddypress-docs' ) : 'Create a Doc';
+		}
+
+		$directory_title = trim( (string) $directory_title );
+
+		if ( '' !== $directory_title ) {
+			return $directory_title;
+		}
+
+		return function_exists( '__' ) ? __( 'Docs Directory', 'buddypress-docs' ) : 'Docs Directory';
+	}
+}

--- a/tests/test-bp-docs-title.php
+++ b/tests/test-bp-docs-title.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Standalone behaviour tests for hcommons_bp_docs_page_title().
+ *
+ * Run with: php tests/test-bp-docs-title.php
+ *
+ * Deliberately framework-free, following tests/test-works-url.php: the
+ * function under test is pure, so we assert over a table of
+ * (view, directory title) -> expected title cases. Tests exercise the
+ * returned value (behaviour), never the implementation.
+ *
+ * @package HCommons
+ */
+
+require_once __DIR__ . '/../inc/bp-docs-title.php';
+
+$cases = array(
+	// The doc-creation screen always gets the "Create a Doc" title, matching
+	// the title BuddyPress Docs itself puts on its theme-compat dummy post.
+	array( 'create', '', 'Create a Doc' ),
+	// A configured directory title never leaks onto the create screen.
+	array( 'create', 'Our Documents', 'Create a Doc' ),
+	// Directory views use the configured directory title when one exists.
+	array( 'directory', 'Our Documents', 'Our Documents' ),
+	// With no configured title, fall back to the plugin's default.
+	array( 'directory', '', 'Docs Directory' ),
+	// Whitespace-only configured titles are treated as unset.
+	array( 'directory', '   ', 'Docs Directory' ),
+	// Unknown views behave like directory views rather than being blank.
+	array( 'mygroups', 'Our Documents', 'Our Documents' ),
+	array( 'mygroups', '', 'Docs Directory' ),
+);
+
+$failures = 0;
+
+foreach ( $cases as $case ) {
+	list( $view, $directory_title, $expected ) = $case;
+
+	$actual = hcommons_bp_docs_page_title( $view, $directory_title );
+
+	if ( $actual !== $expected ) {
+		$failures++;
+		printf(
+			"FAIL: view '%s' with directory title '%s' -> expected '%s', got '%s'\n",
+			$view,
+			$directory_title,
+			$expected,
+			var_export( $actual, true )
+		);
+	}
+}
+
+// The result is always a non-empty string, whatever the inputs.
+$edge = hcommons_bp_docs_page_title( '', '' );
+if ( ! is_string( $edge ) || '' === trim( $edge ) ) {
+	$failures++;
+	printf( "FAIL: empty view/title must still produce a non-empty title, got %s\n", var_export( $edge, true ) );
+}
+
+if ( $failures > 0 ) {
+	printf( "%d test(s) failed.\n", $failures );
+	exit( 1 );
+}
+
+echo "All hcommons_bp_docs_page_title() tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary

Pages served by BuddyPress Docs (e.g. `/docs/` and `/docs/create/?group=...`) rendered with no page title at all, and their document `<title>` was the generic "Docs" post type label. Reported in MESH-Research/knowledge-commons-wordpress#117.

## Root cause

BuddyPress Docs supplies its page titles through BuddyPress theme compat: on `template_include` it resets the global $post to a dummy post titled "Create a Doc" (create screen) or the configured directory title, which a theme's page template then renders via `the_title()`.

This theme, however, hooks `template_include` at priority 99 (`hcommons_bp_docs_template()`) and swaps in its own `bp-docs-template.php` for every Docs page. That file loads only the plugin's inner template parts (`docs-loop.php`, `single/edit.php`), which contain no page heading, so the dummy-post title is never displayed. It echoes an `h2.doc-title` only for single-doc view/edit screens — the create screen and the sitewide directory got nothing (the directory breadcrumb heading in `docs-loop.php` is empty outside group/user/folder contexts). Both directory and create screens also run as the `bp_doc` post-type archive, so `wp_get_document_title()` fell through to the post type label for the browser-tab title.

The root cause is specific to this theme's template override; themes that keep the theme-compat rendering path (e.g. BossChild) show the titles correctly, so the fix belongs here rather than in `hc-custom`.

## Fix

- New pure helper `hcommons_bp_docs_page_title()` (`inc/bp-docs-title.php`) resolving the screen title from the plugin's own sources: "Create a Doc" for the create view, otherwise the configured Docs directory title with the plugin's "Docs Directory" fallback.
- `bp-docs-template.php` and `archive-bp_doc.php` now print that title with the same `h2.doc-title` markup the single-doc views already use, on the create screen and the sitewide directories only — group docs lists keep their breadcrumb heading, single docs keep their real post title.
- A `document_title_parts` filter corrects the document `<title>` on the `bp_doc` archive screens; singular doc queries are untouched.

## Tests

Standalone behavioural tests in `tests/test-bp-docs-title.php`, following the existing `tests/test-works-url.php` pattern (`php tests/test-bp-docs-title.php`). All three theme test files pass.

Fixes MESH-Research/knowledge-commons-wordpress#117