### PR TITLE
fix(bp-docs): stop hijacking the group docs tab template

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -160,6 +160,15 @@ function hcommons_asset_path( $path ) {
  * This filter ensures the correct template is loaded for BP Docs pages.
  */
 function hcommons_bp_docs_template( $template ) {
+	// A group's docs tab (/groups/{slug}/docs/) also reports the docs
+	// component as active, but it must render inside the group's own page —
+	// with the group header and nav — like any other group tab. Leave it to
+	// BuddyPress; hijacking it here strands visitors with no way back to
+	// the group (knowledge-commons-wordpress#121).
+	if ( function_exists( 'bp_is_group' ) && bp_is_group() ) {
+		return $template;
+	}
+
 	// Check if BuddyPress Docs is active and we're on a docs page
 	if ( function_exists( 'bp_docs_is_docs_component' ) && bp_docs_is_docs_component() ) {
 		$custom_template = get_template_directory() . '/bp-docs-template.php';

--- a/tests/test-bp-docs-template.php
+++ b/tests/test-bp-docs-template.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Standalone behaviour tests for hcommons_bp_docs_template().
+ *
+ * Run with: php tests/test-bp-docs-template.php
+ *
+ * Regression guard for MESH-Research/knowledge-commons-wordpress#121: the
+ * template_include filter used to swap in the theme's standalone
+ * bp-docs-template.php for EVERY page where bp_docs_is_docs_component() is
+ * true. That function is also true on a group's docs tab
+ * (/groups/{slug}/docs/), so group docs lost the group header and nav — and
+ * with them, any way back to the group. Group-context docs pages must be left
+ * to BuddyPress, which renders them inside the group's own page like any
+ * other group tab.
+ *
+ * Deliberately framework-free, like the other tests here: we stub the WP/BP
+ * functions the filter consults, include functions.php, and assert on the
+ * returned template path (behaviour), never the implementation. Because the
+ * stubs differ per scenario and PHP functions cannot be redefined, each
+ * scenario runs in its own subprocess, driven by the default 'driver'
+ * invocation.
+ *
+ * @package HCommons
+ */
+
+$scenario = $argv[1] ?? 'driver';
+
+// ---------------------------------------------------------------------------
+// Driver: run each scenario in a subprocess and aggregate the results.
+// ---------------------------------------------------------------------------
+
+if ( 'driver' === $scenario ) {
+	$scenarios = array(
+		'group-docs',
+		'global-docs-directory',
+		'single-doc',
+		'non-docs-page',
+		'no-buddypress-docs',
+	);
+
+	$failures = 0;
+	foreach ( $scenarios as $name ) {
+		$cmd = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __FILE__ ) . ' ' . escapeshellarg( $name );
+		passthru( $cmd, $exit_code );
+		if ( 0 !== $exit_code ) {
+			$failures++;
+		}
+	}
+
+	echo "\n";
+	if ( $failures > 0 ) {
+		echo "RESULT: {$failures} failing scenario(s).\n";
+		exit( 1 );
+	}
+
+	echo "RESULT: all scenarios passed.\n";
+	exit( 0 );
+}
+
+// ---------------------------------------------------------------------------
+// Shared stubs: the minimum needed to load functions.php outside WordPress.
+// ---------------------------------------------------------------------------
+
+define( 'ABSPATH', sys_get_temp_dir() . '/' );
+
+function add_action( ...$args ) {}
+function add_filter( ...$args ) {}
+function add_shortcode( ...$args ) {}
+
+function get_template_directory() {
+	return dirname( __DIR__ );
+}
+
+// ---------------------------------------------------------------------------
+// Per-scenario stubs for the conditional tags the filter consults.
+// ---------------------------------------------------------------------------
+
+switch ( $scenario ) {
+	case 'group-docs':
+		// A group's docs tab: /groups/{slug}/docs/. BP Docs reports its
+		// component as active here, but we are inside a group.
+		function bp_docs_is_docs_component() {
+			return true;
+		}
+		function bp_is_group() {
+			return true;
+		}
+		function is_post_type_archive( $post_type = '' ) {
+			return false;
+		}
+		break;
+
+	case 'global-docs-directory':
+		// The sitewide docs directory: /docs/.
+		function bp_docs_is_docs_component() {
+			return true;
+		}
+		function bp_is_group() {
+			return false;
+		}
+		function is_post_type_archive( $post_type = '' ) {
+			return false;
+		}
+		break;
+
+	case 'single-doc':
+		// A single doc at its global URL: /docs/{slug}. Not group context.
+		function bp_docs_is_docs_component() {
+			return true;
+		}
+		function bp_is_group() {
+			return false;
+		}
+		function is_post_type_archive( $post_type = '' ) {
+			return false;
+		}
+		break;
+
+	case 'non-docs-page':
+		// Any ordinary page with BuddyPress Docs active.
+		function bp_docs_is_docs_component() {
+			return false;
+		}
+		function bp_is_group() {
+			return false;
+		}
+		function is_post_type_archive( $post_type = '' ) {
+			return false;
+		}
+		break;
+
+	case 'no-buddypress-docs':
+		// BuddyPress Docs (and BuddyPress) not loaded at all: none of the
+		// bp_* conditionals exist.
+		function is_post_type_archive( $post_type = '' ) {
+			return false;
+		}
+		break;
+
+	default:
+		fwrite( STDERR, "Unknown scenario '{$scenario}'.\n" );
+		exit( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Load the theme's functions.php and exercise the filter callback.
+// ---------------------------------------------------------------------------
+
+require dirname( __DIR__ ) . '/functions.php';
+
+$original_template = '/wp-core/resolved/block-template.php';
+$docs_template     = get_template_directory() . '/bp-docs-template.php';
+
+try {
+	$returned = hcommons_bp_docs_template( $original_template );
+	$error    = null;
+} catch ( \Throwable $e ) {
+	$returned = null;
+	$error    = $e;
+}
+
+$checks = array(
+	'runs without a fatal error' => null === $error,
+);
+
+switch ( $scenario ) {
+	case 'group-docs':
+		// The crux of #121: group docs must be left to BuddyPress so the
+		// page keeps the group header/nav (the way back to the group).
+		$checks['leaves the group docs tab to BuddyPress'] = $returned === $original_template;
+		break;
+
+	case 'global-docs-directory':
+	case 'single-doc':
+		// Non-group docs pages still need the theme's standalone template
+		// (FSE archive resolution mishandles the bp_doc post type).
+		$checks['uses the theme docs template outside group context'] = $returned === $docs_template;
+		break;
+
+	case 'non-docs-page':
+	case 'no-buddypress-docs':
+		$checks['leaves unrelated pages untouched'] = $returned === $original_template;
+		break;
+}
+
+$failures = 0;
+foreach ( $checks as $label => $passed ) {
+	if ( $passed ) {
+		printf( "PASS  [%s] %s\n", $scenario, $label );
+	} else {
+		$failures++;
+		printf( "FAIL  [%s] %s\n", $scenario, $label );
+		if ( 'runs without a fatal error' === $label && $error ) {
+			printf( "      -> %s\n", $error->getMessage() );
+		}
+	}
+}
+
+exit( $failures > 0 ? 1 : 0 );


### PR DESCRIPTION
## Problem

MESH-Research/knowledge-commons-wordpress#121: a group's docs tab at `/groups/{slug}/docs/` had no way back to the group. The page rendered only the site header and a bare docs loop — no group header, no group nav.

## Root cause

`hcommons_bp_docs_template()` filters `template_include` at priority 99 and swaps in the theme's standalone `bp-docs-template.php` whenever `bp_docs_is_docs_component()` is true. That conditional is deliberately true on group docs tabs too — buddypress-docs' `bp_docs_is_docs_component()` has an explicit `bp_is_current_action( bp_docs_get_docs_slug() )` branch "for cases where we're looking at the Docs library of a group". So the theme was hijacking group docs pages that BuddyPress would otherwise render inside the group's own page (as it does on boss-child, which has no such template swap — only docs template-part overrides).

## Fix

Bail out of the filter when `bp_is_group()` is true, leaving group docs to BuddyPress's normal group rendering. The docs tab now renders like every other group tab: group header (name linked to the group), description card, and the full group nav — Activity / Forum / Docs / Members etc. — which is the way back. This also tidies the page considerably, since the docs list now sits inside the group layout instead of floating on a bare page.

Non-group docs pages (`/docs/` directory, single docs, create/edit) still get the standalone template, which exists because FSE archive resolution mishandles the `bp_doc` post type.

## Tests

- `tests/test-bp-docs-template.php` (new, framework-free like the others here): five scenarios run in subprocesses with stubbed conditional tags, asserting on the template path returned — group docs left to BuddyPress; global directory/single doc keep the theme template; non-docs and no-BuddyPress pages untouched. Written first and red on the group-docs scenario before the fix.
- Existing theme tests still pass (`test-works-url.php`, `test-group-admin-settings.php`).
- Verified end-to-end in the knowledge-commons-wordpress test harness with this theme active: before the fix the rendered group docs page contained no anchor to `/groups/{slug}/` at all; after, it renders the group header/nav with the back link, and the Playwright docs suite passes. A regression spec lands alongside in MESH-Research/knowledge-commons-wordpress (see linked PR there).

Fixes MESH-Research/knowledge-commons-wordpress#121